### PR TITLE
Add ci.opensearch.org maven2/m2 mirrors to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
@@ -86,6 +88,8 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,13 @@
  * in the user manual at https://docs.gradle.org/6.5.1/userguide/multi_project_builds.html
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'plugin-template'


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2/m2 mirrors to avoid Maven Central rate-limiting (HTTP 429) during CI builds.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).